### PR TITLE
Add noopener for promo link

### DIFF
--- a/app.js
+++ b/app.js
@@ -85,8 +85,12 @@ document.addEventListener('DOMContentLoaded', () => {
     if (nv && nv.length < 70) $('#promo-text').innerText = nv;
   });
   $('#promo-link').addEventListener('dblclick', () => {
-    const nv = prompt("Modifier le lien de la promo :", $('#promo-link').href);
-    if (nv && nv.startsWith('http')) $('#promo-link').href = nv;
+    const link = $('#promo-link');
+    const nv = prompt("Modifier le lien de la promo :", link.href);
+    if (nv && nv.startsWith('http')) {
+      link.href = nv;
+      link.rel = 'noopener noreferrer';
+    }
   });
 
   // Init promo image change

--- a/index.html
+++ b/index.html
@@ -109,7 +109,7 @@
     <footer id="promo-banner">
         <img src="assets/banner_sample.png" alt="Promo" />
         <span id="promo-text">Découvrez aussi VFind – défis photo quotidiens !</span>
-        <a href="https://ton-lien.app" target="_blank" class="open-btn" id="promo-link" data-t="open">Ouvrir</a>
+        <a href="https://ton-lien.app" target="_blank" rel="noopener noreferrer" class="open-btn" id="promo-link" data-t="open">Ouvrir</a>
     </footer>
 
     <!-- Scripts -->


### PR DESCRIPTION
## Summary
- secure external promo link with `rel="noopener noreferrer"`
- preserve rel attribute when users customize the link

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841807f60e483219f1247fd4ef28f25