### PR TITLE
Add mask drawing tool

### DIFF
--- a/style.css
+++ b/style.css
@@ -191,6 +191,20 @@ body.dark #scan-canvas {
   background: #191a22;
 }
 
+#mask-overlay {
+  position: absolute;
+  left: 0; top: 0; right: 0; bottom: 0;
+  border-radius: 0.8rem;
+  pointer-events: none;
+}
+
+.mask-rect {
+  position: absolute;
+  background: rgba(0,0,0,0.45);
+  backdrop-filter: blur(3px);
+  border-radius: 0.4rem;
+}
+
 .actions-toolbar {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- enable drawing blur/mask rectangles on the scan
- support rendering mask overlay and export
- style mask overlay elements

## Testing
- `no tests`

------
https://chatgpt.com/codex/tasks/task_e_68418487b78c8321a674e2f10e2df23e