### PR TITLE
Make seal optional and tweak PDF filename

### DIFF
--- a/app.js
+++ b/app.js
@@ -591,7 +591,8 @@ function exportPDF() {
       ctx.fillStyle = "#f9b17a";
       ctx.font = `bold ${Math.floor(canvas.width/13)}px Arial`;
       ctx.textAlign = 'left';
-      ctx.fillText(`VScanPro • ${new Date().toLocaleString()}`, 14, canvas.height-14);
+      const stamp = window.SEAL_TEXT || '';
+      if (stamp) ctx.fillText(stamp.replace('%DATE%', new Date().toLocaleString()), 14, canvas.height-14);
       ctx.restore();
     }
 
@@ -610,7 +611,7 @@ function exportPDF() {
     }
 
     // Export
-    const fname = `VScanPro_${new Date().toISOString().slice(0,10)}.pdf`;
+    const fname = `Scan_${new Date().toISOString().slice(0,10)}.pdf`;
     pdf.save(fname);
 
     // Historique


### PR DESCRIPTION
## Summary
- let the export stamp be overridable with `window.SEAL_TEXT`
- default exported file name is now `Scan_<date>.pdf`

## Testing
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_6841d40ddc588321b24c7863f7ce22dc